### PR TITLE
Add email notification feature to scraper

### DIFF
--- a/Scraper/email_service.py
+++ b/Scraper/email_service.py
@@ -1,0 +1,14 @@
+import smtplib
+from email.mime.text import MIMEText
+
+def send_email(subject, body, sender_email, receiver_email, smtp_server, smtp_port, smtp_password):
+    msg = MIMEText(body, "plain", "utf-8")
+    msg["Subject"] = subject
+    msg["From"] = sender_email
+    msg["To"] = receiver_email
+
+    with smtplib.SMTP_SSL(smtp_server, smtp_port) as server:
+        server.login(sender_email, smtp_password)
+        server.send_message(msg)
+
+    print("✅ Email sent successfully.")

--- a/run_scraper.py
+++ b/run_scraper.py
@@ -1,9 +1,10 @@
 import argparse
 from Scraper.hacker_news import fetch_hacker_news, filter_articles_by_keywords
 from Scraper.save_results import save_articles_to_csv
+from Scraper.email_service import send_email
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Hacker News Scraper with optional keyword filtering")
+    parser = argparse.ArgumentParser(description="Hacker News Scraper with optional keyword filtering and email notification")
     parser.add_argument(
         "--keywords",
         nargs="*",
@@ -14,6 +15,11 @@ if __name__ == "__main__":
         "--output",
         default="articles",
         help="Output filename prefix (default: articles)"
+    )
+    parser.add_argument(
+        "--email",
+        action="store_true",
+        help="Send an email notification with the filtered articles"
     )
 
     args = parser.parse_args()
@@ -34,3 +40,25 @@ if __name__ == "__main__":
         print(f"   Points: {article['points']} | Author: {article['author']} | Comments: {article['comments']}\n")
 
     save_articles_to_csv(articles_to_save, filename_prefix=args.output)
+
+    if args.email and articles_to_save:
+        print("Sending email notification...")
+
+        # ✨ Replace with your actual email configuration
+        sender_email = "your_email@example.com"
+        receiver_email = "recipient_email@example.com"
+        smtp_server = "smtp.gmail.com"
+        smtp_port = 465
+        smtp_password = "your_app_password"
+
+        email_body = "\n\n".join(f"{a['title']} - {a['url']}" for a in articles_to_save)
+
+        send_email(
+            subject="Hacker News Articles",
+            body=email_body,
+            sender_email=sender_email,
+            receiver_email=receiver_email,
+            smtp_server=smtp_server,
+            smtp_port=smtp_port,
+            smtp_password=smtp_password
+        )


### PR DESCRIPTION
Introduced a new email_service module for sending emails via SMTP. Updated run_scraper.py to support an --email flag, which sends filtered articles as an email notification if enabled.