### PR TITLE
Add email CSV attachment support to scraper

### DIFF
--- a/Scraper/email_service.py
+++ b/Scraper/email_service.py
@@ -1,12 +1,26 @@
 import smtplib
 from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.application import MIMEApplication
+import os
 
-def send_email(subject, body, sender_email, receiver_email, smtp_server, smtp_port, smtp_password):
-    msg = MIMEText(body, "plain", "utf-8")
+def send_email(subject, body, sender_email, receiver_email, smtp_server, smtp_port, smtp_password, attachment_path=None):
+    msg = MIMEMultipart()
     msg["Subject"] = subject
     msg["From"] = sender_email
     msg["To"] = receiver_email
 
+    # Add the email body as plain text
+    msg.attach(MIMEText(body, "plain", "utf-8"))
+
+    # Add CSV attachment if provided
+    if attachment_path and os.path.exists(attachment_path):
+        with open(attachment_path, "rb") as f:
+            part = MIMEApplication(f.read(), _subtype="csv")
+            part.add_header("Content-Disposition", "attachment", filename=os.path.basename(attachment_path))
+            msg.attach(part)
+
+    # Send email
     with smtplib.SMTP_SSL(smtp_server, smtp_port) as server:
         server.login(sender_email, smtp_password)
         server.send_message(msg)


### PR DESCRIPTION
Enhanced the email_service to allow sending emails with an optional CSV attachment. Updated run_scraper.py to generate a dated CSV file and attach it to the email if the --email flag is used, improving result sharing and reporting.